### PR TITLE
Add coveralls to travis build.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ lint:
 .PHONY: coverage
 coverage:
 	$(TOX) -c tox.ini -e coverage
+	coveralls
 
 .PHONY: test
 test:

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 .. image:: https://secure.travis-ci.org/mulkieran/justbytes.png?branch=master
    :target: http://travis-ci.org/mulkieran/justbytes
+.. image:: https://coveralls.io/repos/mulkieran/justbytes/badge.svg?branch=master&service=github :target: https://coveralls.io/github/mulkieran/justbytes?branch=master 
 
 Justbytes
 ========

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 tox
+coveralls


### PR DESCRIPTION
Add the coveralls command to the Makefile, add coveralls to the requirements, add a badge to the README. To complete this it is only necessary to turn on coverals for this repo.