### PR TITLE
Remove Decimal from PRECISE_NUMERIC_TYPES.

### DIFF
--- a/src/justbytes/_constants.py
+++ b/src/justbytes/_constants.py
@@ -23,10 +23,10 @@
      * Size units, e.g., Ki, Mi
 """
 
-from decimal import Decimal
+import abc
+
 from numbers import Rational
 
-import abc
 import six
 
 import justbases
@@ -158,6 +158,6 @@ def UNITS():
 
 ROUNDING_METHODS = RoundingMethods.METHODS
 
-PRECISE_NUMERIC_TYPES = tuple(list(six.integer_types) + [Decimal, Rational])
+PRECISE_NUMERIC_TYPES = tuple(list(six.integer_types) + [Rational])
 
 UNIT_TYPES = tuple(list(PRECISE_NUMERIC_TYPES) + [Unit])

--- a/src/justbytes/_size.py
+++ b/src/justbytes/_size.py
@@ -87,10 +87,7 @@ class Range(object):
         if not isinstance(unit, UNIT_TYPES) and  not isinstance(unit, Range):
             return None
         factor = getattr(unit, 'factor', getattr(unit, 'magnitude', None))
-        try:
-            return Fraction(factor if factor is not None else unit)
-        except (ValueError, TypeError):
-            return None
+        return Fraction(factor if factor is not None else unit)
 
     def __init__(self, value=0, units=None):
         """ Initialize a new Range object.
@@ -232,7 +229,7 @@ class Range(object):
             try:
                 (div, rem) = divmod(self._magnitude, Fraction(other))
                 return (Range(div), Range(rem))
-            except (TypeError, ValueError, ZeroDivisionError):
+            except ZeroDivisionError:
                 raise RangeNonsensicalBinOpValueError("divmod", other)
         raise RangeNonsensicalBinOpError("divmod", other)
 
@@ -265,7 +262,7 @@ class Range(object):
         if isinstance(other, PRECISE_NUMERIC_TYPES):
             try:
                 return Range(self._magnitude.__floordiv__(Fraction(other)))
-            except (TypeError, ValueError, ZeroDivisionError):
+            except ZeroDivisionError:
                 raise RangeNonsensicalBinOpValueError("floordiv", other)
         raise RangeNonsensicalBinOpError("floordiv", other)
 
@@ -310,7 +307,7 @@ class Range(object):
         if isinstance(other, PRECISE_NUMERIC_TYPES):
             try:
                 return Range(self._magnitude % Fraction(other))
-            except (TypeError, ValueError, ZeroDivisionError):
+            except ZeroDivisionError:
                 raise RangeNonsensicalBinOpValueError('%', other)
         raise RangeNonsensicalBinOpError("%", other)
 
@@ -321,17 +318,14 @@ class Range(object):
             raise RangeNonsensicalBinOpError("rmod", other)
         try:
             return Range(other.magnitude % Fraction(self._magnitude))
-        except (TypeError, ValueError, ZeroDivisionError):
+        except ZeroDivisionError:
             raise RangeNonsensicalBinOpValueError("rmod", other)
 
     def __mul__(self, other):
         # self * other = mul
         # Therefore, T(mul) = Range and T(other) is a numeric type.
         if isinstance(other, PRECISE_NUMERIC_TYPES):
-            try:
-                return Range(self._magnitude * Fraction(other))
-            except (TypeError, ValueError):
-                raise RangeNonsensicalBinOpError("*", other)
+            return Range(self._magnitude * Fraction(other))
         if isinstance(other, Range):
             raise RangePowerResultError()
         raise RangeNonsensicalBinOpError("*", other)
@@ -377,7 +371,7 @@ class Range(object):
         elif isinstance(other, PRECISE_NUMERIC_TYPES):
             try:
                 return Range(self._magnitude.__truediv__(Fraction(other)))
-            except (TypeError, ValueError, ZeroDivisionError):
+            except ZeroDivisionError:
                 raise RangeNonsensicalBinOpValueError("truediv", other)
         raise RangeNonsensicalBinOpError("truediv", other)
 

--- a/tests/size/initializer_test.py
+++ b/tests/size/initializer_test.py
@@ -60,7 +60,6 @@ class InitializerTestCase(unittest.TestCase):
        strategies.one_of(
           strategies.integers(),
           strategies.fractions(),
-          strategies.decimals().filter(lambda x: x.is_finite()),
           strategies.builds(
              str,
              strategies.decimals().filter(lambda x: x.is_finite())
@@ -70,7 +69,6 @@ class InitializerTestCase(unittest.TestCase):
           strategies.sampled_from(UNITS()),
           strategies.builds(Range, strategies.fractions()),
           strategies.fractions(),
-          strategies.decimals().filter(lambda x: x.is_finite())
        )
     )
     @settings(max_examples=50)

--- a/tests/size/operations_test.py
+++ b/tests/size/operations_test.py
@@ -153,7 +153,7 @@ class DivmodTestCase(unittest.TestCase):
             divmod(Range(12), Range(0))
         with self.assertRaises(RangeNonsensicalBinOpValueError):
             divmod(Range(12), 0)
-        with self.assertRaises(RangeNonsensicalBinOpValueError):
+        with self.assertRaises(RangeNonsensicalBinOpError):
             divmod(Range(12), Decimal('NaN'))
 
     @given(SIZE_STRATEGY, SIZE_STRATEGY.filter(lambda x: x != Range(0)))
@@ -185,7 +185,7 @@ class FloordivTestCase(unittest.TestCase):
             Range(12) // Range(0)
         with self.assertRaises(RangeNonsensicalBinOpValueError):
             Range(12) // 0
-        with self.assertRaises(RangeNonsensicalBinOpValueError):
+        with self.assertRaises(RangeNonsensicalBinOpError):
             Range(12) // Decimal('NaN')
 
     @given(SIZE_STRATEGY, SIZE_STRATEGY.filter(lambda x: x != Range(0)))
@@ -215,7 +215,7 @@ class ModTestCase(unittest.TestCase):
             Range(12) % Range(0)
         with self.assertRaises(RangeNonsensicalBinOpValueError):
             Range(12) % 0
-        with self.assertRaises(RangeNonsensicalBinOpValueError):
+        with self.assertRaises(RangeNonsensicalBinOpError):
             Range(12) % Decimal('NaN')
 
     @given(SIZE_STRATEGY, SIZE_STRATEGY.filter(lambda x: x != Range(0)))
@@ -384,7 +384,7 @@ class TruedivTestCase(unittest.TestCase):
             Range(12) / Range(0)
         with self.assertRaises(RangeNonsensicalBinOpValueError):
             Range(12) / 0
-        with self.assertRaises(RangeNonsensicalBinOpValueError):
+        with self.assertRaises(RangeNonsensicalBinOpError):
             Range(12) / Decimal('NaN')
 
     @given(SIZE_STRATEGY, SIZE_STRATEGY.filter(lambda x: x != Range(0)))

--- a/tests/size/size_test.py
+++ b/tests/size/size_test.py
@@ -20,7 +20,6 @@
 
 import unittest
 
-from decimal import Decimal
 from fractions import Fraction
 
 from justbytes import Range
@@ -104,11 +103,11 @@ class DisplayTestCase(unittest.TestCase):
            (Fraction(512, 1), MiB)
         )
         self.assertEqual(
-           s.components(ValueConfig(min_value=Decimal("0.1"))),
+           s.components(ValueConfig(min_value=Fraction(1, 10))),
            (Fraction(1, 2), GiB)
         )
         self.assertEqual(
-           s.components(ValueConfig(min_value=Decimal(1))),
+           s.components(ValueConfig(min_value=1)),
            (Fraction(512, 1), MiB)
         )
 
@@ -181,7 +180,7 @@ class ConfigurationTestCase(unittest.TestCase):
 
         # a fractional quantity is shown if the value deviates
         # from the whole number of units by more than 1%
-        s = Range(16384 - (Decimal(1024)/100 + 1))
+        s = Range(16384 - (Fraction(1024)/100 + 1))
         self.assertEqual(str(s), "< 15.99 KiB")
 
         # test a very large quantity with no associated abbreviation or prefix
@@ -255,7 +254,7 @@ class ConfigurationTestCase(unittest.TestCase):
            )
         )
 
-        eps = Decimal(1024)/100/2 # 1/2 of 1% of 1024
+        eps = 1024 * Fraction(1, 100) * Fraction(1, 2)
 
         # deviation is less than 1/2 of 1% of 1024
         s = Range(16384 - (eps - 1))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,8 +24,7 @@ from justbytes import UNITS
 
 NUMBERS_STRATEGY = strategies.one_of(
    strategies.integers(),
-   strategies.fractions().map(lambda x: x.limit_denominator(100)),
-   strategies.decimals().filter(lambda x: x.is_finite()),
+   strategies.fractions().map(lambda x: x.limit_denominator(100))
 )
 
 SIZE_STRATEGY = strategies.builds(


### PR DESCRIPTION
In Python, it is possible to do everything necessary with Fraction.

Signed-off-by: mulhern <amulhern@redhat.com>